### PR TITLE
Minor improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 A Toit driver for the DHT11 temperature and humidity sensor.
 
+If you are using the open-source version of Toit, then prefer the dhtxx package.
+
 The temperature is returned in Celcius in a 2-element list. Temperature is stored in the first element. Humidity is stored in the second.
 
 ## Usage
 
-You will need two GPIO pins to use this driver. Normally, a single 
-GPIO pin would be used as output for triggering the sensor, 
+You will need two GPIO pins to use this driver. Normally, a single
+GPIO pin would be used as output for triggering the sensor,
 and subsequently switched to input for reading the response.
 However, since the DHT response comes so quickly, there is no time to
 switch the pin from output to input. Hence two pins are needed: One
@@ -17,7 +19,7 @@ Both should be connected to the data pin of your DTH sensor.
 A simple usage example:
 
 ```
-import ..src.DHT11
+import dht11.DHT11 show *
 
 dataPin   ::= 13
 signalPin ::= 12

--- a/examples/example.toit
+++ b/examples/example.toit
@@ -4,15 +4,15 @@
 
 /**
 This example illustrates how to use the DHT11 sensor with Toit
-Normally, the same GPIO pin would be used as output for triggering the sensor, 
-and subsequently switched to input for reading the response.
+Normally, the same GPIO pin would be used as output for triggering the sensor,
+  and subsequently switched to input for reading the response.
 However since the DHT response comes so quickly, there is no time to
-switch the pin from output to input. Hence two pins are needed: One
-for triggering the data, and a second for reading data.
+  switch the pin from output to input. Hence two pins are needed: One
+  for triggering the data, and a second for reading data.
 Both should be connected to the data pin of your DTH sensor.
 */
 
-import ..src.DHT11
+import dht11.DHT11 show *
 
 dataPin   ::= 13
 signalPin ::= 12

--- a/examples/package.lock
+++ b/examples/package.lock
@@ -1,0 +1,5 @@
+prefixes:
+  dht11: ..
+packages:
+  ..:
+    path: ..

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  dht11:
+    path: ..


### PR DESCRIPTION
Set the output pin to open-drain.

Try to be a bit more efficient in the time-critical loop:
- don't allocate in it.
- avoid unnecessary computations.
- move computations to the sections where we have a tiny bit more time.